### PR TITLE
Update Runtime to 6.9

### DIFF
--- a/me.mitya57.ReText.yaml
+++ b/me.mitya57.ReText.yaml
@@ -1,9 +1,9 @@
 app-id: me.mitya57.ReText
 runtime: org.kde.Platform
-runtime-version: 6.6
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
-base-version: 6.6
+base-version: '6.9'
 command: retext
 rename-icon: retext
 cleanup-commands:


### PR DESCRIPTION
Runtime version 6.6 is end of life, update to the latest one. Also I added quotes so the version number is treated as a string, not as a number (6.10 without quotes would be interpreted as 6.1).

This supersedes #8.